### PR TITLE
Ensure correct resume type during extraction

### DIFF
--- a/background.js
+++ b/background.js
@@ -107,7 +107,7 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
           text,
           companyName: message.companyName,
           companyLink: message.companyLink,
-          type: 'add-to-job',
+          type: message.resumeType || 'normal-resume',
         };
 
         const result = await postData(data);

--- a/popup.html
+++ b/popup.html
@@ -77,7 +77,6 @@
     <select id="resumeType">
       <option value="normal-resume">Normal Resume</option>
       <option value="intern-resume">Intern Resume</option>
-      <option value="normal-cap-resume">Normal Cap Resume</option>
     </select>
   </div>
   <button id="submitBtn">Submit</button>

--- a/popup.js
+++ b/popup.js
@@ -70,6 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('companyLink').value = currentLink;
 
     const { selectedText = '' } = await browser.storage.local.get(['selectedText']);
+    const resumeType = document.getElementById('resumeType').value;
     setLoading(true);
 
     // Prefer enhanced flow that may return a rating; background can also treat this as addJob.
@@ -78,6 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
       companyName,
       companyLink: currentLink,
       tabId: currentTab.id,
+      resumeType,
       fallbackText: selectedText,
     });
 


### PR DESCRIPTION
## Summary
- Send user-selected resume type when extracting job descriptions so API receives correct data
- Remove unsupported resume type option from popup to avoid invalid submissions

## Testing
- `node --check background.js`
- `node --check popup.js`
- `python -m py_compile app.py resume.py`


------
https://chatgpt.com/codex/tasks/task_e_68af358eec8c832997767859f9f389d1