### PR TITLE
Allow extension to reach local API

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,5 @@
+var browser = globalThis.browser || globalThis.chrome;
+
 function createContextMenu() {
   browser.contextMenus.create(
     {

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
     "contextMenus",
     "activeTab",
     "notifications",
-    "storage"
+    "storage",
+    "http://localhost:5000/*"
   ],
   "background": {
     "scripts": ["background.js"]

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,5 @@
+var browser = globalThis.browser || globalThis.chrome;
+
 document.addEventListener('DOMContentLoaded', () => {
   const submitBtn = document.getElementById('submitBtn');
   const extractBtn = document.getElementById('extractBtn');


### PR DESCRIPTION
## Summary
- allow API requests to localhost:5000 by adding host permission
- ensure `browser` polyfill fallback to `chrome` in background and popup scripts

## Testing
- `python -m py_compile app.py resume.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1181479688329a9607fd001012d91