### PR TITLE
Persist background match score for popup reopening

### DIFF
--- a/background.js
+++ b/background.js
@@ -43,8 +43,10 @@ async function postData(data) {
     }
     const rating = Number(json.rating);
     if (!Number.isNaN(rating)) {
+      browser.storage.local.set({ lastMatchScore: rating });
       showNotification('Match Score', `Your resume matches ${rating}%`);
     } else {
+      browser.storage.local.remove('lastMatchScore');
       showNotification('Success', 'Data successfully sent to API.');
     }
     return { success: true, rating };


### PR DESCRIPTION
## Summary
- store the last match score in extension storage when background fetch completes

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b11d3a3b5883298d0cd614dfacde5c