### PR TITLE
Enhance resume matching and job description extraction

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
+from readability import Document
+from lxml.html import fromstring
 from resume import get_job_description_intern, get_job_description_normal, add_to_csv
 
 app = Flask(__name__)
@@ -10,6 +12,7 @@ def save_text():
     data = request.get_json()
 
     text = data.get('text', '').strip()
+    html = data.get('html', '').strip()
     company_name = data.get('companyName', '').strip()
     company_link = data.get('companyLink', '').strip()
     resume_type = data.get('type', 'normal-resume')
@@ -19,6 +22,15 @@ def save_text():
     print(f"Company Link: {company_link or 'N/A'}")
     print(f"Resume Type: {resume_type}")
     print(f"Text Present: {'Yes' if text else 'No'}")
+
+    if not text and html:
+        try:
+            doc = Document(html)
+            summary = doc.summary()
+            text = fromstring(summary).text_content().strip()
+        except Exception as e:
+            print(f"HTML parsing failed: {e}")
+            text = ''
 
     if not text:
         print("Text is empty. Adding job to CSV only.")


### PR DESCRIPTION
## Summary
- generate multiple resume variants and keep the best match
- add heuristic job description extraction with server-side HTML parsing fallback

## Testing
- `pip install readability-lxml`
- `python -m py_compile app.py resume.py`
- `node --check background.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1caeeea7083299d67a6ee66e9bb85